### PR TITLE
build(k8s): force production build to use socialgouv manifests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,11 @@ Test:
   rules:
     - when: never
 
+Production:
+  extends: .autodevops_production
+  variables:
+    KOSKO_APPEND_YAML_FROM: .socialgouv/environments/prod/manifests
+
 Build:
   needs: []
   cache:


### PR DESCRIPTION
<img width=100% src=https://media.giphy.com/media/TKjrbeuXVWgmdTWpVX/giphy.gif />