### PR TITLE
fix(k8s): fix redirect ingress apiVersion

### DIFF
--- a/.socialgouv/environments/prod/yaml/redirect.yaml
+++ b/.socialgouv/environments/prod/yaml/redirect.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
[deprecated in kube 1.22](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/)